### PR TITLE
update Lambda runtime to Python 3.9

### DIFF
--- a/use_cases/custom-cloud9-ssm/lib/index.ts
+++ b/use_cases/custom-cloud9-ssm/lib/index.ts
@@ -174,7 +174,7 @@ export class CustomCloud9Ssm extends cdk.Construct {
         let code: string = fs.readFileSync(CustomCloud9Ssm.ATTACH_PROFILE_FILE_NAME, 'utf8')
 
         const lambdaFunction = new lambda.Function(this,'LambdaFunction', {
-            runtime: lambda.Runtime.PYTHON_3_6,
+            runtime: lambda.Runtime.PYTHON_3_9,
             code: lambda.Code.fromInline(code),
             handler: 'index.handler',
             timeout: cdk.Duration.seconds(60)


### PR DESCRIPTION
*Issue #3*

*Description of changes:*
The runtime parameter of python3.6 is no longer supported for creating or updating AWS Lambda functions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
